### PR TITLE
Compilation fixes for Windows

### DIFF
--- a/lyra2/cuda_lyra2v3.cu
+++ b/lyra2/cuda_lyra2v3.cu
@@ -378,7 +378,7 @@ void lyra2v3_gpu_hash_32_2(uint32_t threads)
 
 		uint32_t rowa;
 		int prev = 3;
-		uint instance = 0;
+		unsigned int instance = 0;
 		for (int i = 0; i < 3; i++)
 		{
 			instance = __shfl(state[(instance >> 2) & 0x3].x, instance & 0x3, 4);

--- a/lyra2/cuda_lyra2v3_sm3.cuh
+++ b/lyra2/cuda_lyra2v3_sm3.cuh
@@ -226,15 +226,15 @@ void lyra2v3_gpu_hash_32_v3(uint32_t threads, uint32_t startNounce, uint2 *outpu
 		reduceDuplexRowSetupV3(1, 0, 2, state, thread);
 		reduceDuplexRowSetupV3(2, 1, 3, state, thread);
 
-		uint instance = 0;
+		unsigned int instance = 0;
 		uint32_t rowa;
 		int prev = 3;
 		for (int i = 0; i < 4; i++)
 		{
 			//rowa = ((uint2*)state)[0].x & 3;  
 
-			instance = ((uint2*)state)[instance & 0xf];
-			rowa = ((uint2*)state)[instance & 0xf] & 0x3;
+			instance = ((uint2*)state)[instance & 0xf].x;
+			rowa = ((uint2*)state)[instance & 0xf].x & 0x3;
 			reduceDuplexRowtV3(prev, rowa, i, state, thread);
 			prev = i;
 		}


### PR DESCRIPTION
Fixes a set of assumptions about types that work on Linux (ie NVCC with GCC as the backend) but not on Windows (with VS2013 as the backend). This allows the kernels to compile on Windows.